### PR TITLE
Update knockout.tooltip.js

### DIFF
--- a/src/knockout.tooltip.js
+++ b/src/knockout.tooltip.js
@@ -14,7 +14,7 @@
             };
             behaviour = $.extend(behaviour, bindings.options);
         }
-        return $.extend(ko.bindingHandlers.tooltip.defaultTooltipOptions, behaviour);
+        return $.extend({}, ko.bindingHandlers.tooltip.defaultTooltipOptions, behaviour);
     },
     init: function (element, valueAccessor, allBindingsAccessor, viewModel) {
         var allBindings = allBindingsAccessor();


### PR DESCRIPTION
$.extend modify properties of the first object.  By using this $.extend(ko.bindingHandlers.tooltip.defaultTooltipOptions, behaviour), we are changing the default properties for all future tooltips.

$.extend({}, ko.bindingHandlers.tooltip.defaultTooltipOptions, behaviour) fixes this because we merge both objects in an empty object.
